### PR TITLE
Telegram Login Process Optimization 

### DIFF
--- a/contract/Portkey.Contracts.CA/CAContractState.cs
+++ b/contract/Portkey.Contracts.CA/CAContractState.cs
@@ -89,6 +89,8 @@ public partial class CAContractState : ContractState
     
     public SingletonState<int> CanRemoveManagerMaxCount { get; set; }
     
-    //cash => {(manager address,transaction count,latest timestamp)}
+    //ca hash => {(manager address,transaction count,latest timestamp)}
     public MappedState<Hash, ManagerStatisticsInfoList> ManagerTransactionStatistics { get; set; }
+    //ca hash => read only status managers for multi-guardian users
+    public MappedState<Hash, ReadOnlyStatusManagers> CaHashToReadOnlyStatusManagers { get; set; }
 }

--- a/contract/Portkey.Contracts.CA/CAContract_Actions.cs
+++ b/contract/Portkey.Contracts.CA/CAContract_Actions.cs
@@ -359,11 +359,11 @@ public partial class CAContract : CAContractImplContainer.CAContractImplBase
         var judgementStrategy = StrategyFactory.Create(strategyNode);
         var judgementResult = (bool)judgementStrategy.Validate(context);
         //after guardian approved, read-only status manager should be cleared.
-        if (clearReadOnlyManager && caHash != null && judgementResult)
-        {
+        if (!clearReadOnlyManager || caHash == null || !judgementResult)
+            return judgementResult;
+        if (IsManagerReadOnly(caHash, Context.Sender))
             State.CaHashToReadOnlyStatusManagers[caHash].ManagerAddresses.Remove(Context.Sender);
-        }
-        return judgementResult;
+        return true;
     }
 
     private void SetDelegator(Hash holderId, ManagerInfo managerInfo)

--- a/contract/Portkey.Contracts.CA/CAContract_Actions.cs
+++ b/contract/Portkey.Contracts.CA/CAContract_Actions.cs
@@ -261,7 +261,7 @@ public partial class CAContract : CAContractImplContainer.CAContractImplBase
         // Where is the code for double check approved guardians?
         // Don't forget to assign GuardianApprovedCount
         var isJudgementStrategySatisfied =
-            IsJudgementStrategySatisfied(holderInfo.GuardianList.Guardians.Count, 1, holderInfo.JudgementStrategy);
+            IsJudgementStrategySatisfied(holderInfo.GuardianList.Guardians.Count, 1, holderInfo.JudgementStrategy, caHash:null, clearReadOnlyManager:false);
         if (!isJudgementStrategySatisfied)
         {
             caAddress = null;
@@ -321,7 +321,7 @@ public partial class CAContract : CAContractImplContainer.CAContractImplBase
         // Where is the code for double check approved guardians?
         // Don't forget to assign GuardianApprovedCount
         var isJudgementStrategySatisfied =
-            IsJudgementStrategySatisfied(holderInfo.GuardianList.Guardians.Count, 1, holderInfo.JudgementStrategy);
+            IsJudgementStrategySatisfied(holderInfo.GuardianList.Guardians.Count, 1, holderInfo.JudgementStrategy, caHash:null, clearReadOnlyManager:false);
         if (!isJudgementStrategySatisfied)
         {
             caAddress = null;
@@ -344,7 +344,8 @@ public partial class CAContract : CAContractImplContainer.CAContractImplBase
         Assert(holderInfo.CreateChainId == Context.ChainId, "Not on registered chain");
     }
 
-    private bool IsJudgementStrategySatisfied(int guardianCount, int guardianApprovedCount, StrategyNode strategyNode)
+    private bool IsJudgementStrategySatisfied(int guardianCount, int guardianApprovedCount, StrategyNode strategyNode,
+        Hash caHash = null, bool clearReadOnlyManager = true)
     {
         var context = new StrategyContext()
         {
@@ -356,7 +357,13 @@ public partial class CAContract : CAContractImplContainer.CAContractImplBase
         };
 
         var judgementStrategy = StrategyFactory.Create(strategyNode);
-        return (bool)judgementStrategy.Validate(context);
+        var judgementResult = (bool)judgementStrategy.Validate(context);
+        //after guardian approved, read-only status manager should be cleared.
+        if (clearReadOnlyManager && caHash != null && judgementResult)
+        {
+            State.CaHashToReadOnlyStatusManagers[caHash].ManagerAddresses.Remove(Context.Sender);
+        }
+        return judgementResult;
     }
 
     private void SetDelegator(Hash holderId, ManagerInfo managerInfo)
@@ -544,8 +551,6 @@ public partial class CAContract : CAContractImplContainer.CAContractImplBase
         Assert(input.SubscriptionId > 0, "Invalid input subscription id.");
         Assert(State.OidcProviderData[input.Type] != null, "StartOracleDataFeedsTaskRequest OidcProviderData doesn't exist");
         Assert(State.OracleContract.Value != null, "Oracle contract should be set.");
-        Assert(!(State.OidcProviderData[input.Type].SubscriptionId.Equals(input.SubscriptionId)
-            && State.OidcProviderData[input.Type].SpecificData != null), "the SubscriptionId has started before");
 
         var specificData = GetJobSepc(State.OidcProviderData[input.Type].JwksEndpoint);
         var specificDataWrapper = new AetherLink.Contracts.DataFeeds.Coordinator.SpecificData

--- a/contract/Portkey.Contracts.CA/CAContract_Helpers.cs
+++ b/contract/Portkey.Contracts.CA/CAContract_Helpers.cs
@@ -24,6 +24,27 @@ public partial class CAContract
             Value = CheckVerifierSignatureAndData(request.GuardianApproved, request.MethodName, request.CaHash, request.OperationDetails, true)
         };
     }
+
+    private static bool IsReadOnlyManager(int platform, int guardiansCount, IEnumerable<GuardianInfo> approvedGuardians)
+    {
+        var readOnlyManager = platform == (int)PlatformSource.Sdk && guardiansCount > 1;
+        if (!readOnlyManager)
+        {
+            return false;
+        }
+        var telegramApprovedGuardians = approvedGuardians.Where(g => g.Type.Equals(GuardianType.OfTelegram)).ToList();
+        if (telegramApprovedGuardians.Count == 0)
+        {
+            return false;
+        }
+
+        return telegramApprovedGuardians.Select(telegramApprovedGuardian => 
+            telegramApprovedGuardian?.VerificationInfo != null 
+            && telegramApprovedGuardian.VerificationInfo.Id != null 
+            && telegramApprovedGuardian?.VerificationInfo.Signature != null 
+            && telegramApprovedGuardian?.VerificationInfo.VerificationDoc != null)
+            .All(valid => valid);
+    }
     
     private bool CheckVerifierSignatureAndData(GuardianInfo guardianInfo, string methodName, Hash caHash = null,
         string operationDetails = null, bool preValidation = false)

--- a/contract/Portkey.Contracts.CA/CAContract_Helpers.cs
+++ b/contract/Portkey.Contracts.CA/CAContract_Helpers.cs
@@ -25,9 +25,9 @@ public partial class CAContract
         };
     }
 
-    private static bool IsReadOnlyManager(int platform, IEnumerable<GuardianInfo> approvedGuardians)
+    private static bool IsReadOnlyManager(int platform, int guardiansCount, IReadOnlyCollection<GuardianInfo> approvedGuardians)
     {
-        if (platform != (int)PlatformSource.Telegram)
+        if (platform != (int)PlatformSource.Telegram || guardiansCount <= 1)
         {
             return false;
         }

--- a/contract/Portkey.Contracts.CA/CAContract_Helpers.cs
+++ b/contract/Portkey.Contracts.CA/CAContract_Helpers.cs
@@ -25,10 +25,9 @@ public partial class CAContract
         };
     }
 
-    private static bool IsReadOnlyManager(int platform, int guardiansCount, IEnumerable<GuardianInfo> approvedGuardians)
+    private static bool IsReadOnlyManager(int platform, IEnumerable<GuardianInfo> approvedGuardians)
     {
-        var readOnlyManager = platform == (int)PlatformSource.Sdk && guardiansCount > 1;
-        if (!readOnlyManager)
+        if (platform != (int)PlatformSource.Telegram)
         {
             return false;
         }

--- a/contract/Portkey.Contracts.CA/CAContract_Helpers.cs
+++ b/contract/Portkey.Contracts.CA/CAContract_Helpers.cs
@@ -25,9 +25,9 @@ public partial class CAContract
         };
     }
 
-    private static bool IsReadOnlyManager(int platform, int guardiansCount, IReadOnlyCollection<GuardianInfo> approvedGuardians)
+    private static bool IsReadOnlyManager(Platform platform, int guardiansCount, IReadOnlyCollection<GuardianInfo> approvedGuardians)
     {
-        if (platform != (int)PlatformSource.Telegram || guardiansCount <= 1)
+        if (platform != Platform.Telegram || guardiansCount <= 1)
         {
             return false;
         }

--- a/contract/Portkey.Contracts.CA/CAContract_Managers.cs
+++ b/contract/Portkey.Contracts.CA/CAContract_Managers.cs
@@ -39,7 +39,7 @@ public partial class CAContract
         var methodName = nameof(OperationType.SocialRecovery).ToLower();
         int guardianApprovedCount;
         int guardianCount;
-        var isReadOnlyManager = IsReadOnlyManager(input.Platform, input.GuardiansApproved); 
+        var isReadOnlyManager = IsReadOnlyManager(input.Platform, guardians.Count, input.GuardiansApproved); 
         if (isReadOnlyManager)
         {
             var telegramApprovedGuardians = input.GuardiansApproved.Where(g => g.Type.Equals(GuardianType.OfTelegram)).ToList();
@@ -608,15 +608,15 @@ public partial class CAContract
         return managerStatisticsInfoList;
     }
     
-    public override Empty RemoveReadOnlyManager(IsManagerReadOnlyInput input)
+    public override Empty RemoveReadOnlyManager(RemoveReadOnlyManagerInput input)
     {
-        Assert(Context.Sender == State.Admin.Value, "No SetManagerMaxCount permission.");
         Assert(input != null, "Invalid input.");
         Assert(input?.CaHash != null, "Invalid caHash.");
-        Assert(input?.Manager != null, "Invalid manager.");
+        CheckManagerInfoPermission(input.CaHash, Context.Sender);
+        
         if (State.CaHashToReadOnlyStatusManagers[input.CaHash] != null)
         {
-            State.CaHashToReadOnlyStatusManagers[input.CaHash].ManagerAddresses.Remove(input.Manager);
+            State.CaHashToReadOnlyStatusManagers[input.CaHash].ManagerAddresses.Remove(Context.Sender);
         }
         return new Empty();
     }

--- a/contract/Portkey.Contracts.CA/CAContract_Managers.cs
+++ b/contract/Portkey.Contracts.CA/CAContract_Managers.cs
@@ -612,12 +612,14 @@ public partial class CAContract
     {
         Assert(input != null, "Invalid input.");
         Assert(input?.CaHash != null, "Invalid caHash.");
+        Assert(input.GuardiansApproved is { Count: > 0 }, "Invalid approved guardians.");
         CheckManagerInfoPermission(input.CaHash, Context.Sender);
         
-        if (State.CaHashToReadOnlyStatusManagers[input.CaHash] != null)
-        {
-            State.CaHashToReadOnlyStatusManagers[input.CaHash].ManagerAddresses.Remove(Context.Sender);
-        }
+        if (!IsManagerReadOnly(input.CaHash, Context.Sender))
+            return new Empty();
+        var operationDetails = Context.Sender.ToBase58();
+        var methodName = nameof(OperationType.SocialRecovery).ToLower();
+        GuardianApprovedCheck(input.CaHash, input.GuardiansApproved, OperationType.SocialRecovery, methodName, operationDetails);
         return new Empty();
     }
 

--- a/contract/Portkey.Contracts.CA/CAContract_Managers.cs
+++ b/contract/Portkey.Contracts.CA/CAContract_Managers.cs
@@ -39,7 +39,7 @@ public partial class CAContract
         var methodName = nameof(OperationType.SocialRecovery).ToLower();
         int guardianApprovedCount;
         int guardianCount;
-        var isReadOnlyManager = IsReadOnlyManager(input.Platform, guardians.Count, input.GuardiansApproved); 
+        var isReadOnlyManager = IsReadOnlyManager(input.Platform, input.GuardiansApproved); 
         if (isReadOnlyManager)
         {
             var telegramApprovedGuardians = input.GuardiansApproved.Where(g => g.Type.Equals(GuardianType.OfTelegram)).ToList();
@@ -606,6 +606,19 @@ public partial class CAContract
         var managerStatisticsInfoList = State.ManagerTransactionStatistics[input?.CaHash];
         Assert(managerStatisticsInfoList is { ManagerStatisticsInfos.Count: > 0 }, "There's no manager statistics");
         return managerStatisticsInfoList;
+    }
+    
+    public override Empty RemoveReadOnlyManager(IsManagerReadOnlyInput input)
+    {
+        Assert(Context.Sender == State.Admin.Value, "No SetManagerMaxCount permission.");
+        Assert(input != null, "Invalid input.");
+        Assert(input?.CaHash != null, "Invalid caHash.");
+        Assert(input?.Manager != null, "Invalid manager.");
+        if (State.CaHashToReadOnlyStatusManagers[input.CaHash] != null)
+        {
+            State.CaHashToReadOnlyStatusManagers[input.CaHash].ManagerAddresses.Remove(input.Manager);
+        }
+        return new Empty();
     }
 
     public override BoolValue IsManagerReadOnly(IsManagerReadOnlyInput input)

--- a/contract/Portkey.Contracts.CA/CAContract_TransferLimit.cs
+++ b/contract/Portkey.Contracts.CA/CAContract_TransferLimit.cs
@@ -106,7 +106,7 @@ public partial class CAContract
         var holderJudgementStrategy = holderInfo.JudgementStrategy ?? Strategy.DefaultStrategy();
         var onSyncChain = holderInfo.CreateChainId != 0 && holderInfo.CreateChainId != Context.ChainId;
         Assert(IsJudgementStrategySatisfied(holderInfo.GuardianList!.Guardians.Count, guardianApprovedCount,
-                holderJudgementStrategy),
+                holderJudgementStrategy, caHash:caHash),
             onSyncChain ? "Processing on the chain..." : "JudgementStrategy validate failed");
     }
 

--- a/protobuf/ca_contract.proto
+++ b/protobuf/ca_contract.proto
@@ -53,7 +53,7 @@ service CAContract {
   
   rpc IsManagerReadOnly (IsManagerReadOnlyInput) returns (google.protobuf.BoolValue) {option (aelf.is_view) = true;}
   
-  rpc RemoveReadOnlyManager (IsManagerReadOnlyInput) returns (google.protobuf.Empty) {}
+  rpc RemoveReadOnlyManager (RemoveReadOnlyManagerInput) returns (google.protobuf.Empty) {}
 
   // If the managerInfo is already exists, return true
   rpc AddManagerInfo (AddManagerInfoInput) returns (google.protobuf.Empty) {}
@@ -424,6 +424,10 @@ message SocialRecoveryInput {
 message IsManagerReadOnlyInput {
   aelf.Hash ca_hash = 1;
   aelf.Address manager = 2;
+}
+
+message RemoveReadOnlyManagerInput{
+  aelf.Hash ca_hash = 1;
 }
 
 message AddManagerInfoInput {

--- a/protobuf/ca_contract.proto
+++ b/protobuf/ca_contract.proto
@@ -418,7 +418,7 @@ message SocialRecoveryInput {
   ManagerInfo manager_info = 3;
   string referral_code = 4;
   string project_code = 5;
-  int32 platform = 6;
+  Platform platform = 6;
 }
 
 message IsManagerReadOnlyInput {
@@ -640,17 +640,11 @@ message Invited {
   string project_code = 5;
 }
 
-enum OperationType {
-  Unknown = 0;
-  CreateCAHolder = 1;
-  SocialRecovery = 2;
-  AddGuardian = 3;
-  RemoveGuardian = 4;
-  UpdateGuardian = 5;
-  RemoveOtherManagerInfo = 6;
-  SetLoginAccount = 7;
-  Approve = 8;
-  ModifyTransferLimit = 9;
-  GuardianApproveTransfer = 10;
-  UnSetLoginAccount = 11;
+enum Platform {
+  UNDEFINED = 0;
+  ANDROID = 1;
+  IOS = 2;
+  WEB = 3;
+  SDK = 4;
+  TELEGRAM = 5;
 }

--- a/protobuf/ca_contract.proto
+++ b/protobuf/ca_contract.proto
@@ -428,6 +428,7 @@ message IsManagerReadOnlyInput {
 
 message RemoveReadOnlyManagerInput{
   aelf.Hash ca_hash = 1;
+  repeated ca.GuardianInfo guardians_approved = 2;
 }
 
 message AddManagerInfoInput {

--- a/protobuf/ca_contract.proto
+++ b/protobuf/ca_contract.proto
@@ -33,8 +33,6 @@ service CAContract {
 
   rpc UpdateGuardian (UpdateGuardianInput) returns (google.protobuf.Empty) {}
   
-  rpc AppendGuardianPoseidonHash(AppendGuardianRequest) returns (google.protobuf.Empty) {}
-
   // If Guardian is already setted, return true
   rpc SetGuardianForLogin (SetGuardianForLoginInput) returns (google.protobuf.Empty) {}
 
@@ -52,6 +50,8 @@ service CAContract {
 
   // If ManagerInfo is already binded, return true
   rpc SocialRecovery (SocialRecoveryInput) returns (google.protobuf.Empty) {}
+  
+  rpc IsManagerReadOnly (IsManagerReadOnlyInput) returns (google.protobuf.BoolValue) {option (aelf.is_view) = true;}
 
   // If the managerInfo is already exists, return true
   rpc AddManagerInfo (AddManagerInfoInput) returns (google.protobuf.Empty) {}
@@ -348,20 +348,6 @@ message UpdateGuardianInput{
   repeated GuardianInfo guardians_approved = 4;
 }
 
-message AppendGuardianRequest{
-  repeated AppendGuardianInput input = 1;
-}
-message AppendGuardianInput {
-  aelf.Hash ca_hash = 1;
-  repeated PoseidonGuardian guardians = 2;
-}
-
-message PoseidonGuardian {
-  GuardianType type = 1;
-  aelf.Hash identifier_hash = 2;
-  string poseidon_identifier_hash = 3;
-}
-
 message SetGuardianForLoginInput {
   aelf.Hash ca_hash = 1;
   Guardian guardian = 2;
@@ -430,6 +416,12 @@ message SocialRecoveryInput {
   ManagerInfo manager_info = 3;
   string referral_code = 4;
   string project_code = 5;
+  int32 platform = 6;
+}
+
+message IsManagerReadOnlyInput {
+  aelf.Hash ca_hash = 1;
+  aelf.Address manager = 2;
 }
 
 message AddManagerInfoInput {

--- a/protobuf/ca_contract.proto
+++ b/protobuf/ca_contract.proto
@@ -52,6 +52,8 @@ service CAContract {
   rpc SocialRecovery (SocialRecoveryInput) returns (google.protobuf.Empty) {}
   
   rpc IsManagerReadOnly (IsManagerReadOnlyInput) returns (google.protobuf.BoolValue) {option (aelf.is_view) = true;}
+  
+  rpc RemoveReadOnlyManager (IsManagerReadOnlyInput) returns (google.protobuf.Empty) {}
 
   // If the managerInfo is already exists, return true
   rpc AddManagerInfo (AddManagerInfoInput) returns (google.protobuf.Empty) {}

--- a/protobuf/ca_contract_impl.proto
+++ b/protobuf/ca_contract_impl.proto
@@ -112,10 +112,6 @@ service CAContractImpl {
   
   // add a verifying key for a circuit or update the old one
   rpc AddOrUpdateVerifyingKey (VerifyingKey) returns (google.protobuf.Empty);
-
-  rpc AppendGoogleGuardianPoseidon(AppendSingleGuardianPoseidonInput) returns (google.protobuf.Empty) {}
-
-  rpc AppendAppleGuardianPoseidon(AppendSingleGuardianPoseidonInput) returns (google.protobuf.Empty) {}
   
   // query the verifying key of a circuit (by circuit_id)
   rpc GetVerifyingKey (google.protobuf.StringValue) returns (VerifyingKey) {
@@ -549,12 +545,6 @@ message ZkPublicKeyInfo {
   repeated string public_key_chunks = 3;
 }
 
-message AppendSingleGuardianPoseidonInput {
-  aelf.Hash ca_hash = 1;
-  aelf.Hash identifier_hash = 2;
-  string poseidon_identifier_hash = 3;
-}
-
 message VerificationTransactionInfo {
   int32 from_chain_id = 1;
   int64 parent_chain_height = 2;
@@ -590,4 +580,16 @@ message ManagerStatisticsInfo {
   aelf.Address address = 1;
   google.protobuf.Timestamp latest_transaction_timestamp = 2;
   int32 transaction_frequency = 3;
+}
+
+message ReadOnlyStatusManagers {
+  repeated aelf.Address manager_addresses = 1;
+}
+
+enum PlatformSource {
+  UNDEFINED = 0;
+  ANDROID = 1;
+  IOS = 2;
+  WEB = 3;
+  SDK = 4;
 }

--- a/protobuf/ca_contract_impl.proto
+++ b/protobuf/ca_contract_impl.proto
@@ -586,11 +586,17 @@ message ReadOnlyStatusManagers {
   repeated aelf.Address manager_addresses = 1;
 }
 
-enum PlatformSource {
-  UNDEFINED = 0;
-  ANDROID = 1;
-  IOS = 2;
-  WEB = 3;
-  SDK = 4;
-  TELEGRAM = 5;
+enum OperationType {
+  Unknown = 0;
+  CreateCAHolder = 1;
+  SocialRecovery = 2;
+  AddGuardian = 3;
+  RemoveGuardian = 4;
+  UpdateGuardian = 5;
+  RemoveOtherManagerInfo = 6;
+  SetLoginAccount = 7;
+  Approve = 8;
+  ModifyTransferLimit = 9;
+  GuardianApproveTransfer = 10;
+  UnSetLoginAccount = 11;
 }

--- a/protobuf/ca_contract_impl.proto
+++ b/protobuf/ca_contract_impl.proto
@@ -592,4 +592,5 @@ enum PlatformSource {
   IOS = 2;
   WEB = 3;
   SDK = 4;
+  TELEGRAM = 5;
 }


### PR DESCRIPTION
1. Social recovery manager adds read-only status for Guardian login scenarios on Telegram
2. Add the logic of clearing manager read-only status after Guardian Approval to 12 or more methods of CA contract
3. Add a read-only contract view method for querying
4. Add a method to delete read-only contracts for managers
#945